### PR TITLE
Post claimed credit to user's ORCID account (as a "service" record)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ SERVER_SESSION_SECRET_KEY="__REPLACE_THIS_EXAMPLE_VALUE__"
 
 ORCID_ACCESS_TOKEN_URL="https://sandbox.orcid.org/oauth/token"
 ORCID_AUTHORIZE_BASE_URL="https://sandbox.orcid.org/oauth/authorize"
-ORCID_OAUTH_SCOPES="/authenticate"
+ORCID_API_BASE_URL="https://api.sandbox.orcid.org/v3.0"
+ORCID_OAUTH_SCOPES="/authenticate /activities/update"
 ORCID_CLIENT_ID="__REPLACE_THIS_EXAMPLE_VALUE__"
 ORCID_CLIENT_SECRET="__REPLACE_THIS_EXAMPLE_VALUE__"
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can run the following commands inside the container (i.e. at the container's
   # From outside the container:
   # $ docker compose exec app poetry run djlint --reformat --lint .
   ```
-- Format JavaScript files (if you have [Node.js  and NPM](https://nodejs.org/en/download/prebuilt-installer) installed):
+- Format JavaScript files (if you have [Node.js and NPM](https://nodejs.org/en/download/prebuilt-installer) installed):
   ```sh
   npx --yes prettier --write nmdc-orcid-creditor-proxy/*.js
   

--- a/nmdc_orcid_creditor/config.py
+++ b/nmdc_orcid_creditor/config.py
@@ -20,7 +20,8 @@ class Config(BaseSettings):
     # Reference: https://info.orcid.org/documentation/api-tutorials/api-tutorial-add-and-update-data-on-an-orcid-record/
     ORCID_ACCESS_TOKEN_URL: str = "https://orcid.org/oauth/token"  # ends with "/token"
     ORCID_AUTHORIZE_BASE_URL: str = "https://orcid.org/oauth/authorize"  # ends with "/authorize"
-    ORCID_OAUTH_SCOPES: str = ""  # space-delimited list
+    ORCID_API_BASE_URL: str = "https://api.orcid.org/v3.0"  # ends with "/v3.0"
+    ORCID_OAUTH_SCOPES: str = "/authenticate /activities/update"  # space-delimited list
     ORCID_CLIENT_ID: str = ""
     ORCID_CLIENT_SECRET: str = ""
 

--- a/nmdc_orcid_creditor/main.py
+++ b/nmdc_orcid_creditor/main.py
@@ -198,6 +198,8 @@ async def post_api_credits_claim(
     # Report the credit to ORCID (as a "service" credit). If unsuccessful, return an error response and abort
     # (instead of proceeding to record the claim event into the Google Sheets document).
     #
+    # TODO: Store the identifiers returned by ORCID, in case we want to _update_ the records later.
+    #
     # References:
     # - https://github.com/ORCID/orcid-model/blob/master/src/main/resources/record_3.0/README.md#add-record-items
     #

--- a/nmdc_orcid_creditor/main.py
+++ b/nmdc_orcid_creditor/main.py
@@ -195,10 +195,43 @@ async def post_api_credits_claim(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ORCID access token")
     orcid_id = orcid_access_token["orcid"]
 
-    # FIXME: Here, claim the credit via ORCID's API. If unsuccessful, return an error response and abort
-    #        (instead of proceeding to record the claim event into the Google Sheets document).
+    # Report the credit to ORCID (as a "service" credit). If unsuccessful, return an error response and abort
+    # (instead of proceeding to record the claim event into the Google Sheets document).
     #
-    pass
+    # References:
+    # - https://github.com/ORCID/orcid-model/blob/master/src/main/resources/record_3.0/README.md#add-record-items
+    #
+    try:
+        orcid_api_url = f"{cfg.ORCID_API_BASE_URL}/{orcid_id}/service"
+        response = httpx.post(
+            orcid_api_url,
+            headers={"Authorization": f"Bearer {orcid_access_token['access_token']}"},
+            json={
+                # TODO: Consider including a department and other information (see payload examples in ORCID docs).
+                "role-title": f"{credit_type}",
+                # FIXME: Obtain the date from the spreadsheet (or omit it?).
+                "start-date": {"year": {"value": "1970"}, "month": {"value": "01"}, "day": {"value": "01"}},
+                # FIXME: Obtain the date from the spreadsheet (or omit it?).
+                "end-date": {"year": {"value": "2024"}, "month": {"value": "12"}, "day": {"value": "31"}},
+                "organization": {
+                    "name": "National Microbiome Data Collaborative",
+                    "address": {"city": "Berkeley", "region": "California", "country": "US"},
+                    "disambiguated-organization": {
+                        "disambiguated-organization-identifier": "https://ror.org/05cwx3318",
+                        "disambiguation-source": "ROR",
+                    },
+                },
+                "url": {"value": "https://microbiomedata.org/"},
+            },
+        )
+
+        # If the response wasn't `201`, abort; i.e., don't record that the credit has been claimed.
+        if response.status_code != 201:
+            logger.debug(f"{response.status_code=}\n{response.content=}")
+            raise RuntimeError("Failed to record claim.")
+    except (httpx.HTTPError, RuntimeError) as error:
+        logger.exception(error)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to record claim.")
 
     # Record the claim event into the Google Sheets document via the proxy.
     try:


### PR DESCRIPTION
On this branch, I'm working on updating the FastAPI app (our API server) to post the claimed credit to the logged-in user's ORCID account (as a "service" record).