### PR TITLE
Implement GHA workflow that builds and publishes container image to GHCR

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -1,0 +1,76 @@
+# GitHub Actions workflow that builds and publishes a container image to GHCR.
+name: Build and push container image to GHCR
+
+# This workflow will run whenever a Release is published.
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  # Run the tests defined in `.github/workflows/test.yaml`.
+  test:
+    name: Run tests
+    uses: ./.github/workflows/test.yml
+  build-and-push-image:
+    name: Build and push container image
+    runs-on: ubuntu-latest
+    needs: test  # makes it so this job runs only after the tests pass
+    steps:
+    - name: Check out commit  # Docs: https://github.com/actions/checkout
+      uses: actions/checkout@v4
+
+    # Note: These steps are about setting the package version string in `pyproject.toml`.
+    - name: Set up Python  # Docs: https://github.com/actions/setup-python
+      uses: actions/setup-python@v5
+      with:
+        # Specify a Python version that satisfies the `tool.poetry.dependencies.python`
+        # version requirement specified in `pyproject.toml`.
+        python-version: '3.10'
+    - name: Install Poetry  # Docs: https://github.com/snok/install-poetry
+      uses: snok/install-poetry@v1
+    - name: Update package version  # Docs: https://python-poetry.org/docs/cli/#version
+      run: poetry version ${{ github.ref_name }}
+    
+    # Note: These steps are about building and publishing the container image.
+    - name: Authenticate with container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # Use the `docker/metadata-action` action to extract values that can
+      # be incorporated into the tags and labels of the resulting container
+      # image. The step's `id` ("meta") can be used in subsequent steps to
+      # reference the _outputs_ of this step.
+      # Docs: https://github.com/docker/metadata-action
+    - name: Prepare metadata of container image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/microbiomedata/nmdc-orcid-creditor
+        flavor: latest=auto
+        tags: type=semver,pattern={{version}}
+        # Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+        labels: |
+          org.opencontainers.image.title="NMDC ORCID Creditor"
+          org.opencontainers.image.description="FastAPI web application NMDC team members use to distribute ORCID credits to NMDC contributors."
+          org.opencontainers.image.vendor="National Microbiome Data Collaborative"
+          org.opencontainers.image.documentation="https://github.com/microbiomedata/nmdc-orcid-creditor"
+          org.opencontainers.image.url="https://github.com/microbiomedata/nmdc-orcid-creditor"
+          org.opencontainers.image.source="https://github.com/microbiomedata/nmdc-orcid-creditor"
+          org.opencontainers.image.version="{{version}}"
+          org.opencontainers.image.revision="{{sha}}"
+      # Use the `docker/build-push-action` action to build the image described
+      # by the specified Dockerfile. If the build succeeds, push the image to GHCR.
+      # This action uses the `tags` and `labels` parameters to tag and label
+      # the image, respectively, with the _outputs_ from the "meta" step above.
+      # Docs: https://github.com/docker/build-push-action#usage
+    - name: Build and push container image
+      id: push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
   # Allow people to trigger the workflow manually from the GitHub UI.
   # Docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch: { }
+  # Allow this workflow to be called by other workflows.
+  # Reference: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call: { }
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,21 @@ WORKDIR /app
 RUN apt update && \
     apt install -y nodejs npm
 
-# Install Poetry.
-RUN python -m pip install poetry
+# Install Poetry (a dependency manager) and Uvicorn (a web application server).
+RUN python -m pip install \
+    poetry \
+    uvicorn[standard]
 
-# Use Poetry to install Python package dependencies.
+# Use Poetry to install Python package dependencies; without installing the project, itself.
 # Reference: https://python-poetry.org/docs/cli/#install
 ADD poetry.lock    /app/poetry.lock
 ADD pyproject.toml /app/pyproject.toml
-RUN poetry install --no-interaction
+RUN poetry install --no-interaction --no-root
 
-# Run the FastAPI development server, accepting HTTP requests from any host,
-# include those outside of the container (e.g. the container host system).
-# Reference: https://fastapi.tiangolo.com/deployment/manually/
+# Copy the repository contents into the image.
+COPY . /app
+
+# Use Uvicorn to serve the FastAPI application on port 8000, accepting requests from any host.
+# Reference: https://fastapi.tiangolo.com/deployment/manually/#run-the-server-program
 EXPOSE 8000
-CMD [ "poetry", "run", "fastapi", "dev", "--host", "0.0.0.0", "/app/nmdc_orcid_creditor/main.py" ]
+CMD [ "uvicorn", "nmdc_orcid_creditor.main:app", "--host", "0.0.0.0", "--port", "8000" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,3 +28,7 @@ services:
       #       within the container.
       #
       - ".:/app"
+    # Run the FastAPI development server, accepting HTTP requests from any host,
+    # include hosts outside of the container (e.g. the container host system).
+    # Reference: https://fastapi.tiangolo.com/deployment/manually/
+    command: [ "poetry", "run", "fastapi", "dev", "--host", "0.0.0.0", "/app/nmdc_orcid_creditor/main.py" ]


### PR DESCRIPTION
On this branch, I added a GitHub Actions workflow that (a) runs the tests, (b) builds a container image, and (c) pushes that container image to GitHub Container Registry (GHCR). I also made some changes to the `Dockerfile` to support this.