### PR TITLE
Store affiliation "put-code" in Google Sheets document for future reference

### DIFF
--- a/nmdc-orcid-creditor-proxy/Code.gs.js
+++ b/nmdc-orcid-creditor-proxy/Code.gs.js
@@ -70,7 +70,8 @@ function claimCreditsByTypeAndOrcidId(creditType, orcidId, affiliationPutCode) {
   // and the column number of the column indicating the affiliation's "put-code".
   // Note: Google Sheets column numbers are 1-based.
   const claimedAtColumnNumber = columnNames.indexOf("column.CLAIMED_AT") + 1;
-  const affiliationPutCodeColumnNumber = columnNames.indexOf("column.AFFILIATION_PUT_CODE") + 1;
+  const affiliationPutCodeColumnNumber =
+    columnNames.indexOf("column.AFFILIATION_PUT_CODE") + 1;
 
   // Find the row numbers of the rows having the specified credit type and ORCID ID pair.
   let rowNumbers = [];
@@ -92,7 +93,10 @@ function claimCreditsByTypeAndOrcidId(creditType, orcidId, affiliationPutCode) {
     const claimedAtCell = dataRange.getCell(rowNumber, claimedAtColumnNumber);
     claimedAtCell.setValue(claimedAt);
 
-    const affiliationPutCodeCell = dataRange.getCell(rowNumber, affiliationPutCodeColumnNumber);
+    const affiliationPutCodeCell = dataRange.getCell(
+      rowNumber,
+      affiliationPutCodeColumnNumber,
+    );
     affiliationPutCodeCell.setValue(affiliationPutCode);
   });
 
@@ -158,10 +162,16 @@ function doPost(event) {
   const _ = validateSharedSecret(queryParams["shared_secret"]);
   const orcidId = validateOrcidId(queryParams["orcid_id"]);
   const creditType = validateCreditType(queryParams["credit_type"]);
-  const affiliationPutCode = validateCreditType(queryParams["affiliation_put_code"]);
+  const affiliationPutCode = validateCreditType(
+    queryParams["affiliation_put_code"],
+  );
 
   // Update the specified credits and then get all credits associated with that ORCID ID.
-  const credits = claimCreditsByTypeAndOrcidId(creditType, orcidId, affiliationPutCode);
+  const credits = claimCreditsByTypeAndOrcidId(
+    creditType,
+    orcidId,
+    affiliationPutCode,
+  );
 
   return ContentService.createTextOutput(
     JSON.stringify({ orcid_id: orcidId, credits }),

--- a/nmdc_orcid_creditor/helpers.py
+++ b/nmdc_orcid_creditor/helpers.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import re
 
+
 def extract_put_code_from_location_header(location_header: str) -> Optional[str]:
     r"""
     Extracts the affiliation's "put-code" from the specified string;

--- a/nmdc_orcid_creditor/helpers.py
+++ b/nmdc_orcid_creditor/helpers.py
@@ -1,0 +1,32 @@
+from typing import Optional
+import re
+
+def extract_put_code_from_location_header(location_header: str) -> Optional[str]:
+    r"""
+    Extracts the affiliation's "put-code" from the specified string;
+    which we will have received as the value of the "location" header
+    in the response to an ORCID API request we used to create an affiliation.
+
+    Reference: https://info.orcid.org/hands-on-with-the-orcid-api/3-write-to-an-orcid-record-post/ (search for "put-code")
+
+    >>> extract_put_code_from_location_header("https://api.orcid.org/v3.0/0000-0000-0000-000X/service/12345")  # production API example
+    '12345'
+    >>> extract_put_code_from_location_header("https://api.sandbox.orcid.org/v3.0/0000-0000-0000-000X/service/12345")  # sandbox API example
+    '12345'
+    >>> extract_put_code_from_location_header("http://api.sandbox.orcid.org/v3.0/0000-0000-0000-000X/service/12345")  # plain HTTP
+    '12345'
+    >>> extract_put_code_from_location_header("https://api.orcid.org/v3.0/0000-0000-0000-000X/service/") is None  # no numbers at end
+    True
+    >>> extract_put_code_from_location_header("") is None  # empty
+    True
+    """
+
+    the_put_code = None
+
+    # If the location header matches the pattern, extract the "put-code".
+    pattern = r"^https?://.*orcid\.org.*/(\d+)$"
+    match_obj = re.match(pattern, location_header)
+    if match_obj:
+        the_put_code = match_obj.group(1)
+
+    return the_put_code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,13 @@ httpx = "^0.27.2"
 djlint = "^1.35.2"
 
 [tool.pytest.ini_options]
-# Make it so that, when someone runs `$ poetry run pytest`, in addition to running the tests, it
-# also (via the `pytest-cov` plugin) measures test coverage of the source code directory.
-# Reference: https://pytest-cov.readthedocs.io/en/latest/config.html#configuration
-addopts = "--cov=nmdc_orcid_creditor"
+# Make it so that, when someone runs `$ poetry run pytest`, in addition to running the tests,
+# it also runs doctests defined within Python modules and (via the `pytest-cov` plugin)
+# it also measures test coverage of the source code directory.
+# References:
+# - https://docs.pytest.org/en/stable/how-to/doctest.html#how-to-run-doctests
+# - https://pytest-cov.readthedocs.io/en/latest/config.html#configuration
+addopts = "--doctest-modules --cov=nmdc_orcid_creditor"
 
 [tool.black]
 # Make it so that, when someone runs `$ poetry run black`, these default CLI options are used.


### PR DESCRIPTION
On this branch, I updated the app so that it stores the numeric "put-code" returned by ORCID, which can be used to update the created affiliation. I also configure Pytest to run doctests by default.