### PR TITLE
Allow admin to specify URL containing description of affiliation

### DIFF
--- a/nmdc_orcid_creditor/main.py
+++ b/nmdc_orcid_creditor/main.py
@@ -251,7 +251,7 @@ async def post_api_credits_claim(
     credit_to_claim = credits_to_claim[0]
     logger.debug(f"Claiming credit: {credit_to_claim}")
 
-    # Get the affiliation type associated with the credit type.
+    # Get the affiliation type associated with the credit.
     affiliation_type = credit_to_claim.get("column.AFFILIATION_TYPE", "").strip()
     if affiliation_type not in ["membership", "service"]:
         logger.error(f"The credit has an invalid affiliation type. Credit: {credit_to_claim}")
@@ -259,6 +259,9 @@ async def post_api_credits_claim(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"The credit has an invalid affiliation type. Please report this to an administrator.",
         )
+
+    # Get the URL associated with the credit.
+    credit_url = credit_to_claim.get("column.DETAILS_URL", "").strip()
 
     # Create the ("membership" or "service") affiliation on the specified ORCID profile and extract the newly-created
     # affiliation's "put-code" from the API response. If we fail to do either thing, return an error response and abort
@@ -289,7 +292,9 @@ async def post_api_credits_claim(
                         "disambiguation-source": "ROR",
                     },
                 },
-                "url": {"value": "https://microbiomedata.org/"},
+                # Note: Submitting a "url.value" value of "" is OK. In that situation,
+                #       ORCID will not display the "URL" field for this affiliation.
+                "url": {"value": credit_url},
             },
         )
 

--- a/nmdc_orcid_creditor/templates/base.html.jinja
+++ b/nmdc_orcid_creditor/templates/base.html.jinja
@@ -17,6 +17,11 @@
               href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
               integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
               crossorigin="anonymous">
+        <!-- Load Bootstrap Icons from CDN. -->
+        <link rel="stylesheet"
+              href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+              integrity="sha256-9kPW/n5nn53j4WMRYAxe9c1rCY96Oogo/MKSVdKzPmI="
+              crossorigin="anonymous">
         <!-- Customize values of theme variables used by Bootstrap.
              References:
              - https://getbootstrap.com/docs/5.3/customize/css-variables/#root-variables

--- a/nmdc_orcid_creditor/templates/credits.html.jinja
+++ b/nmdc_orcid_creditor/templates/credits.html.jinja
@@ -158,9 +158,11 @@
                         // Populate the cells in this row.
                         const cells = rowEl.querySelectorAll("td");
                         const creditType = credit["column.CREDIT_TYPE"];
+                        const creditUrl = credit["column.DETAILS_URL"];
                         const claimedAt = formatTimestamp(credit["column.CLAIMED_AT"]);
                         const isClaimed = claimedAt !== "";
                         cells[0].innerHTML = creditType;
+                        cells[0].innerHTML += creditUrl === "" ? "" : `<br /><a href="${creditUrl}" target="_blank" class="text-decoration-none small">Details <i class="bi bi-box-arrow-up-right"></i></a>`;
                         cells[1].innerHTML = claimedAt;
                         if (isClaimed) {
                             cells[2].innerHTML = "<span>None</span>";


### PR DESCRIPTION
On this branch, I updated the FastAPI "claim" endpoint and "credits" template to use the value in the `column.DETAILS_URL` column (on the relevant row) of the spreadsheet. I also introduced Bootstrap Icons as a dependency (loaded via CDN).