### PR TITLE
Allow admin to omit start and/or end date from affiliation 

### DIFF
--- a/nmdc_orcid_creditor/main.py
+++ b/nmdc_orcid_creditor/main.py
@@ -263,20 +263,27 @@ async def post_api_credits_claim(
             detail=f"The credit has an invalid affiliation type. Please report this to an administrator.",
         )
 
-    # Get the start date and end date associated with the credit; and parse them into year, month, and day strings.
+    # Get the start date and end date strings associated with the credit; and—for any
+    # that isn't empty—parse it into its corresponding year, month, and day strings.
+    has_start_date = False
+    has_end_date = False
     start_date = credit_to_claim.get("column.START_DATE", "").strip()
     end_date = credit_to_claim.get("column.END_DATE", "").strip()
     try:
-        start_year, start_month, start_day = extract_year_month_day_from_datetime_string(start_date)
-        end_year, end_month, end_day = extract_year_month_day_from_datetime_string(end_date)
+        if len(start_date) > 0:
+            start_year, start_month, start_day = extract_year_month_day_from_datetime_string(start_date)
+            logger.debug(f"Parsed {start_date=} into {start_year=}, {start_month=}, {start_day=}")
+            has_start_date = True
+        if len(end_date) > 0:
+            end_year, end_month, end_day = extract_year_month_day_from_datetime_string(end_date)
+            logger.debug(f"Parsed {end_date=} into {end_year=}, {end_month=}, {end_day=}")
+            has_end_date = True
     except ValueError as error:
         logger.error(f"Failed to parse start date or end date. Details: {error}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"The credit has an invalid date associated with it. Please report this to an administrator.",
         )
-    logger.debug(f"Parsed {start_date=} into {start_year=}, {start_month=}, {start_day=}")
-    logger.debug(f"Parsed {end_date=} into {end_year=}, {end_month=}, {end_day=}")
 
     # Get the URL associated with the credit.
     credit_url = credit_to_claim.get("column.DETAILS_URL", "").strip()
@@ -292,20 +299,25 @@ async def post_api_credits_claim(
     #
     try:
         orcid_api_url = f"{cfg.ORCID_API_BASE_URL}/{orcid_id}/{affiliation_type}"
+
+        # Build the start date and end date items (or lack thereof) for the API request payload (dictionary).
+        #
+        # Note: The ORCID API does allow the top-level "start-date" and "end-date" fields to be omitted.
+        #       When "start-date" is omitted, the person's ORCID profile will show only the end date (e.g. "2023-12-31 | Team member").
+        #       When "end-date" is omitted, the person's ORCID profile will append "to present"      (e.g. "2022-01-01 to present | Team member").
+        #       When both are omitted, the person's ORCID profile will not show any dates            (e.g. "Team member").
+        #        
+        start_date_item = {"start-date": {"year": {"value": start_year}, "month": {"value": start_month}, "day": {"value": start_day}}} if has_start_date else {}
+        end_date_item = {"end-date": {"year": {"value": end_year}, "month": {"value": end_month}, "day": {"value": end_day}}} if has_end_date else {}
+
         response = httpx.post(
             orcid_api_url,
             headers={"Authorization": f"Bearer {orcid_access_token['access_token']}"},
             json={
                 # TODO: Consider including a department and other information (see payload examples in ORCID docs).
                 "role-title": f"{credit_type}",
-                #
-                # Note: The ORCID API does allow the top-level "start-date" and "end-date" fields to be omitted.
-                #       When "start-date" is omitted, the person's ORCID profile will show only the end date (e.g. "2023-12-31 | Team member").
-                #       When "end-date" is omitted, the person's ORCID profile will append "to present"      (e.g. "2022-01-01 to present | Team member").
-                #       When both are omitted, the person's ORCID profile will not show any dates            (e.g. "Team member").
-                #
-                "start-date": {"year": {"value": start_year}, "month": {"value": start_month}, "day": {"value": start_day}},
-                "end-date": {"year": {"value": end_year}, "month": {"value": end_month}, "day": {"value": end_day}},
+                **start_date_item,
+                **end_date_item,
                 "organization": {
                     "name": "National Microbiome Data Collaborative",
                     "address": {"city": "Berkeley", "region": "California", "country": "US"},

--- a/nmdc_orcid_creditor/templates/credits.html.jinja
+++ b/nmdc_orcid_creditor/templates/credits.html.jinja
@@ -78,12 +78,64 @@
                 };
 
                 /**
-                 * Helper function that formats the specified timestamp as a UTC string.
+                 * Helper function that formats the specified timestamp as a string.
+                 *
+                 * Note: The format of the string depends upon the user's locale. For example,
+                 *       in the "en-US" locale, the format is "May 1, 2025 at 1:23 PM".
+                 *
+                 * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
                  */
                 const formatTimestamp = (rawTimestamp) => {
+                    // Note: We pass `undefined` as the locale, so the formatter uses the web browser's default locale.
+                    const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                    });
                     const date = new Date(rawTimestamp.trim());
                     if (!isNaN(date.valueOf())) {
-                        return date.toUTCString();
+                        return dateTimeFormatter.format(date);
+                    } else {
+                        return "";
+                    }
+                };
+
+                /**
+                 * Helper function that formats the specified combination of timestamps
+                 * as a string whose format resembles the format ORCID would use when
+                 * displaying an affiliation having those same start and end dates.
+                 *
+                 * Note: Through experimentation, we found that ORCID uses these formats:
+                 *       1. "1999-01-01 to 2025-12-31", when both dates are defined
+                 *       2. "1999-01-01 to present", when only the start date is defined
+                 *       3. "2025-12-31", when only the end date is defined
+                 *       4. "", when neither date is defined
+                 *
+                 *       In the case of this function, the format of the _date_ portion(s)
+                 *       of the string depends upon the web browser's default locale. For
+                 *       example, if the web browser's default locale is "en-US", the
+                 *       _date_ portion(s) of the string will be formatted as "12/31/2025",
+                 *       not as "2025-12-31".
+                 */
+                const formatDateRange = (startTimestamp = "", endTimestamp = "") => {
+                    // Note: We pass `undefined` as the locale, so the formatter uses the web browser's default locale.
+                    const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                    });
+                    const startDate = new Date(startTimestamp.trim());
+                    const endDate = new Date(endTimestamp.trim());
+                    const hasStartDate = !isNaN(startDate.valueOf());
+                    const hasEndDate = !isNaN(endDate.valueOf());
+                    if (hasStartDate && hasEndDate) {
+                        return `${dateTimeFormatter.format(startDate)} to ${dateTimeFormatter.format(endDate)}`;
+                    } else if (hasStartDate && !hasEndDate) {
+                        return `${dateTimeFormatter.format(startDate)} to present`;
+                    } else if (!hasStartDate && hasEndDate) {
+                        return dateTimeFormatter.format(endDate);
                     } else {
                         return "";
                     }
@@ -158,10 +210,12 @@
                         // Populate the cells in this row.
                         const cells = rowEl.querySelectorAll("td");
                         const creditType = credit["column.CREDIT_TYPE"];
+                        const dateRange = formatDateRange(credit["column.START_DATE"], credit["column.END_DATE"]);
                         const creditUrl = credit["column.DETAILS_URL"];
                         const claimedAt = formatTimestamp(credit["column.CLAIMED_AT"]);
                         const isClaimed = claimedAt !== "";
                         cells[0].innerHTML = creditType;
+                        cells[0].innerHTML += dateRange === "" ? "" : `<br /><span class="small text-muted">${dateRange}</span>`;
                         cells[0].innerHTML += creditUrl === "" ? "" : `<br /><a href="${creditUrl}" target="_blank" class="text-decoration-none small">Details <i class="bi bi-box-arrow-up-right"></i></a>`;
                         cells[1].innerHTML = claimedAt;
                         if (isClaimed) {


### PR DESCRIPTION
On this branch, I updated the FastAPI to no longer try parsing the start/end date string retrieved from the spreadsheet if it is an empty string. In those cases, the FastAPI app will _omit_ the associated item(s) from the API request payload that it sends to the ORCID API.

Also on this branch—since I was focusing on dates—I (a) made it so the Credits table (web page) shows the affiliations start and end dates; and I (b) refined the format of the "Claimed at" date. All dates now use a format consistent with the web browser's default locale.