### PR TITLE
Display toast notification when user claims a credit

### DIFF
--- a/nmdc_orcid_creditor/templates/credits.html.jinja
+++ b/nmdc_orcid_creditor/templates/credits.html.jinja
@@ -1,6 +1,22 @@
 {% extends "base.html.jinja" %}
 {% block body %}
     <div class="block-body-credits">
+        <div class="toast-container position-fixed top-0 end-0 p-3">
+            <!-- This template, itself, is invisible. Elements will be created from it via JavaScript. -->
+            <template>
+                <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+                    <div class="toast-header">
+                        <img src="{{ url_for("static", path="/favicon.png") }}"
+                             class="rounded me-2"
+                             alt="NMDC Logo"
+                             height="24"
+                             width="24">
+                        <strong class="me-auto"></strong>
+                    </div>
+                    <div class="toast-body"></div>
+                </div>
+            </template>
+        </div>
         <span class="alert-container">
             <!-- This template, itself, is invisible. Elements will be created from it via JavaScript. -->
             <template>
@@ -75,6 +91,39 @@
                     const messageEl = alertEl.querySelector(".message");
                     messageEl.innerHTML = message;
                     alertContainerEl.appendChild(alertEl);
+                };
+
+                /**
+                * Temporarily show a toast having the specified header text and body text.
+                *
+                * Reference: https://getbootstrap.com/docs/5.3/components/toasts/
+                */
+                const showToast = (headerText, bodyText) => {
+                    // Get references to the HTML template, fragment, and other elements involved.
+                    const toastContainerEl = blockEl.querySelector(".toast-container");
+                    const templateEl = toastContainerEl.querySelector("template");
+                    const toastFragment = templateEl.content.cloneNode(true);
+                    const headerEl = toastFragment.querySelector(".toast-header > strong");
+                    const bodyEl = toastFragment.querySelector(".toast-body");
+
+                    // Set the header text and body text.
+                    headerEl.textContent = headerText;
+                    bodyEl.textContent = bodyText;
+
+                    // Add the toast to the container element, then get the toast as an _element_.
+                    // Note: Bootstrap's `Toast` constructor does not work when passed a fragment.
+                    toastContainerEl.appendChild(toastFragment);
+                    const toastEl = toastContainerEl.lastElementChild;
+
+                    // Configure the toast to be removed from the DOM once it's hidden from view.
+                    // Note: This is in an attempt to prevent memory leaks.
+                    toastEl.addEventListener("hidden.bs.toast", () => {
+                        toastContainerEl.removeChild(toastEl);
+                    });
+
+                    // Bootstrap-ify the toast and show it.
+                    const bootstrapToast = new bootstrap.Toast(toastEl);
+                    bootstrapToast.show();
                 };
 
                 /**
@@ -182,7 +231,8 @@
                         });
                         if (response.ok) {
                             const json = await response.json();
-                            displayCredits(json["credits"])
+                            displayCredits(json["credits"]);
+                            showToast("Claimed", "Credit claimed successfully.");
                         } else {
                             throw new Error(`Response status: ${response.status}`);
                         }


### PR DESCRIPTION
On this branch, I made it so the credits page displays a toast notification once a credit has been successfully claimed.

Here's a video showing the toast notification (it appears in the upper right after a few seconds). It automatically disappears after being visible for five seconds (the disappearing is not shown in this video).

https://github.com/user-attachments/assets/cc3bb369-ebbf-4096-9325-b4ec8a0e8267

We can refine the content of the toast notification later.